### PR TITLE
Harden PowerShell update path by removing remote module import

### DIFF
--- a/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
+++ b/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
@@ -78,16 +78,6 @@ function Download-OpenTelemetry([string]$Version, [string]$Path) {
     return $dlPath
 }
 
-function Download-OpenTelemetry-Install-Module([string]$Version, [string]$Path) {
-    $module = "OpenTelemetry.DotNet.Auto.psm1"
-    $dlUrl = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/$Version/$module"
-    $dlPath = Join-Path $Path $module
-
-    Invoke-WebRequest -Uri $dlUrl -OutFile $dlPath -UseBasicParsing
-
-    return $dlPath
-}
-
 function Get-Environment-Variables-Table([string]$InstallDir, [string]$OTelServiceName) {
     $COR_PROFILER_PATH_32 = Join-Path $InstallDir "/win-x86/OpenTelemetry.AutoInstrumentation.Native.dll"
     $COR_PROFILER_PATH_64 = Join-Path $InstallDir "/win-x64/OpenTelemetry.AutoInstrumentation.Native.dll"
@@ -471,21 +461,14 @@ function Update-OpenTelemetryCore() {
     }
 
     $tempDir = Get-Temp-Directory
-    $modulePath = Download-OpenTelemetry-Install-Module $newestInstallVersion $tempDir
+    $archivePath = Download-OpenTelemetry $newestInstallVersion $tempDir
+    Install-OpenTelemetryCore -InstallDir $installDir -LocalPath $archivePath -RegisterAssembliesInGAC $RegisterAssembliesInGAC
 
-    Remove-Module OpenTelemetry.Dotnet.Auto
-    Import-Module $modulePath
-
-    Install-OpenTelemetryCore -InstallDir $installDir -RegisterAssembliesInGAC $RegisterAssembliesInGAC
     if ($RegisterIIS) {
         Register-OpenTelemetryForIIS
     }
 
-    # Release module
-    Remove-Module OpenTelemetry.Dotnet.Auto
-    
-    # Cache install module
-    Move-Item -Path $modulePath -Destination $installDir
+    Remove-Item $archivePath
 }
 
 <#


### PR DESCRIPTION
### Motivation
- The update flow downloaded and immediately `Import-Module` on a remote `OpenTelemetry.DotNet.Auto.psm1`, which allowed execution of unvalidated remote code and introduced a supply-chain RCE vector.
- The change removes the risky behavior while preserving the ability to update the product.

### Description
- Removed the `Download-OpenTelemetry-Install-Module` helper that downloaded a `.psm1` file from GitHub releases (file: `script-templates/OpenTelemetry.DotNet.Auto.psm1.template`).
- Reworked `Update-OpenTelemetryCore` to download the release ZIP via `Download-OpenTelemetry`, then call `Install-OpenTelemetryCore -LocalPath <archive>` to perform installation from the archive instead of importing a remote module.
- Deleted the `Import-Module` / remote `.psm1` execution path and removed caching of the fetched module; the downloaded archive is removed after the update completes.
- Changes are confined to `script-templates/OpenTelemetry.DotNet.Auto.psm1.template` and preserve existing install logic while removing the untrusted code execution step.

### Testing
- Searched the updated template with `rg -n "Download-OpenTelemetry-Install-Module|Import-Module \$modulePath|Move-Item -Path \$modulePath"` and found no matches, confirming removal of the risky path (success).
- Reviewed the diff with `git diff` / `git status` to confirm only the intended changes were applied (success).
- Committed the change (`git commit -m "Harden update flow by removing remote module import"`) to the branch (success).
- Attempted to validate `Update-OpenTelemetryCore` with PowerShell, but `pwsh` is not installed in the environment so runtime verification could not be executed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcd7accef08323a678e8077ca0b31f)