### PR TITLE
Guard BeginMethod fast-path signature construction against oversized metadata signatures

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
@@ -94,6 +94,7 @@ HRESULT TracerTokens::WriteBeginMethodWithArgumentsArray(void*           rewrite
     ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
     auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
+
     COR_SIGNATURE signature[signatureBufferSize];
     unsigned      offset = 0;
     signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
@@ -288,6 +289,12 @@ HRESULT TracerTokens::WriteBeginMethod(void*                             rewrite
             argumentsSignatureSize[i] = signatureSize;
             signatureLength += signatureSize;
         }
+    }
+
+    if (signatureLength > signatureBufferSize)
+    {
+        Logger::Debug("BeginMethod fast-path signature is too large for buffer. Falling back to arguments array path.");
+        return WriteBeginMethodWithArgumentsArray(rewriterWrapperPtr, integrationTypeRef, currentType, instruction);
     }
 
     COR_SIGNATURE signature[signatureBufferSize];


### PR DESCRIPTION
### Motivation
- The fast-path `BeginMethod` builds a generic-instantiation signature into a fixed 500-byte stack buffer using metadata-derived argument signature lengths, which can be unbounded and could overflow the buffer for crafted or unusually large signatures.
- Preventing a potential stack buffer overflow in native signature construction is required while preserving existing instrumentation behavior for normal signatures.

### Description
- Add a bounds check in `TracerTokens::WriteBeginMethod` after computing `signatureLength` to ensure it does not exceed `signatureBufferSize`.
- If the computed signature is too large, log a debug message and fall back to the existing slow-path `WriteBeginMethodWithArgumentsArray` instead of writing into the fixed stack buffer.
- Keep the fast-path unchanged for safe signature sizes so normal performance is retained.
- Change made in `src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp`.

### Testing
- Ran `git diff --check` to validate the patch and ensure no whitespace/format issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8ab68dca883239932d9dfd97ff731)