### PR TITLE
Ensure Docker network helper returns network name consistently

### DIFF
--- a/test/IntegrationTests/Helpers/DockerNetworkHelper.cs
+++ b/test/IntegrationTests/Helpers/DockerNetworkHelper.cs
@@ -30,7 +30,7 @@ internal static class DockerNetworkHelper
         {
             if (network.IPAM.Config[0].Gateway == IntegrationTestsGateway)
             {
-                return network.ID;
+                return IntegrationTestsNetworkName;
             }
             else
             {


### PR DESCRIPTION
### Motivation
- Fix an inconsistent return value in `DockerNetworkHelper.SetupIntegrationTestsNetworkAsync` where the existing-network branch returned `network.ID` while the method is documented and callers expect a network name, which can break Testcontainers `.WithNetwork(...)` and cause flaky integration tests.

### Description
- Update the existing-network branch to return `IntegrationTestsNetworkName` instead of `network.ID` so the helper always returns the Docker network name.

### Testing
- Attempted to run the test tooling but `dotnet` is not available in this environment (`dotnet --version` returned `command not found`), so no automated tests were executed; the source change was inspected to confirm the return value was updated to `IntegrationTestsNetworkName`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7696164b88323bc427a964b6b6517)